### PR TITLE
php8.1にする

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Push to GitHub Container Registry
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v3
         with:
           username: senbot
           password: ${{ secrets.SENBOT_CR_PAT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/php:7.3
+FROM cimg/php:8.1.12
 
 VOLUME /var/lib/docker
 


### PR DESCRIPTION
circleci/phpは更新が停止していたので、後継のcimg/phpに切り替え

https://hub.docker.com/r/circleci/php
https://circleci.com/developer/ja/images/image/cimg/php